### PR TITLE
Add missing options to goimports

### DIFF
--- a/cmd/goimports/goimports.go
+++ b/cmd/goimports/goimports.go
@@ -54,6 +54,7 @@ func init() {
 	flag.StringVar(&options.LocalPrefix, "local", "", "put imports beginning with this string after 3rd-party packages; comma-separated list")
 	flag.BoolVar(&options.FormatOnly, "format-only", false, "if true, don't fix imports and only format. In this mode, goimports is effectively gofmt, with the addition that imports are grouped into sections.")
 	flag.BoolVar(&options.MergeAll, "merge-all", false, "if true, merge all imports into a single group")
+	flag.BoolVar(&options.Simplify, "s", false, "if true, simplify code like gofmt -s does")
 }
 
 func report(err error) {

--- a/cmd/goimports/goimports.go
+++ b/cmd/goimports/goimports.go
@@ -53,6 +53,7 @@ func init() {
 	flag.BoolVar(&options.AllErrors, "e", false, "report all errors (not just the first 10 on different lines)")
 	flag.StringVar(&options.LocalPrefix, "local", "", "put imports beginning with this string after 3rd-party packages; comma-separated list")
 	flag.BoolVar(&options.FormatOnly, "format-only", false, "if true, don't fix imports and only format. In this mode, goimports is effectively gofmt, with the addition that imports are grouped into sections.")
+	flag.BoolVar(&options.MergeAll, "merge-all", false, "if true, merge all imports into a single group")
 }
 
 func report(err error) {

--- a/internal/imports/fix_test.go
+++ b/internal/imports/fix_test.go
@@ -2999,6 +2999,26 @@ import (
 	}.processTest(t, "golang.org/fake", "x.go", nil, &Options{MergeAll: true}, want)
 }
 
+func TestSimplify(t *testing.T) {
+	const input = `package main
+
+var a = []foo{foo{}}
+`
+	const want = `package main
+
+var a = []foo{{}}
+`
+
+	testConfig{
+		modules: []packagestest.Module{
+			{
+				Name:  "golang.org/fake",
+				Files: fm{"x.go": input},
+			},
+		},
+	}.processTest(t, "golang.org/fake", "x.go", nil, &Options{Simplify: true}, want)
+}
+
 func TestSymbolSearchStarvation(t *testing.T) {
 	// This test verifies the fix for golang/go#67923: searching through
 	// candidates should not starve when the context is cancelled.

--- a/internal/imports/fix_test.go
+++ b/internal/imports/fix_test.go
@@ -2958,6 +2958,47 @@ var _, _ = fmt.Sprintf, dot.Dot
 	}.processTest(t, "golang.org/fake", "x.go", nil, nil, want)
 }
 
+func TestMergeAll(t *testing.T) {
+	const input = `package main
+
+import (
+	_ "g"
+
+	_ "c"
+)
+
+import _ "f"
+
+import (
+	_ "b"
+	_ "e"
+	_ "d"
+
+	_ "a"
+)
+`
+	const want = `package main
+
+import (
+	_ "a"
+	_ "b"
+	_ "c"
+	_ "d"
+	_ "e"
+	_ "f"
+	_ "g"
+)
+`
+	testConfig{
+		modules: []packagestest.Module{
+			{
+				Name:  "golang.org/fake",
+				Files: fm{"x.go": input},
+			},
+		},
+	}.processTest(t, "golang.org/fake", "x.go", nil, &Options{MergeAll: true}, want)
+}
+
 func TestSymbolSearchStarvation(t *testing.T) {
 	// This test verifies the fix for golang/go#67923: searching through
 	// candidates should not starve when the context is cancelled.

--- a/internal/imports/gofmt_rewrite.go
+++ b/internal/imports/gofmt_rewrite.go
@@ -1,0 +1,113 @@
+package imports
+
+import (
+	"go/ast"
+	"go/token"
+	"reflect"
+	"unicode"
+	"unicode/utf8"
+)
+
+// Values/types for special cases.
+var (
+	objectPtrNil = reflect.ValueOf((*ast.Object)(nil))
+	scopePtrNil  = reflect.ValueOf((*ast.Scope)(nil))
+
+	identType     = reflect.TypeOf((*ast.Ident)(nil))
+	objectPtrType = reflect.TypeOf((*ast.Object)(nil))
+	positionType  = reflect.TypeOf(token.NoPos)
+	callExprType  = reflect.TypeOf((*ast.CallExpr)(nil))
+	scopePtrType  = reflect.TypeOf((*ast.Scope)(nil))
+)
+
+func isWildcard(s string) bool {
+	rune, size := utf8.DecodeRuneInString(s)
+	return size == len(s) && unicode.IsLower(rune)
+}
+
+// match reports whether pattern matches val,
+// recording wildcard submatches in m.
+// If m == nil, match checks whether pattern == val.
+func match(m map[string]reflect.Value, pattern, val reflect.Value) bool {
+	// Wildcard matches any expression. If it appears multiple
+	// times in the pattern, it must match the same expression
+	// each time.
+	if m != nil && pattern.IsValid() && pattern.Type() == identType {
+		name := pattern.Interface().(*ast.Ident).Name
+		if isWildcard(name) && val.IsValid() {
+			// wildcards only match valid (non-nil) expressions.
+			if _, ok := val.Interface().(ast.Expr); ok && !val.IsNil() {
+				if old, ok := m[name]; ok {
+					return match(nil, old, val)
+				}
+				m[name] = val
+				return true
+			}
+		}
+	}
+
+	// Otherwise, pattern and val must match recursively.
+	if !pattern.IsValid() || !val.IsValid() {
+		return !pattern.IsValid() && !val.IsValid()
+	}
+	if pattern.Type() != val.Type() {
+		return false
+	}
+
+	// Special cases.
+	switch pattern.Type() {
+	case identType:
+		// For identifiers, only the names need to match
+		// (and none of the other *ast.Object information).
+		// This is a common case, handle it all here instead
+		// of recursing down any further via reflection.
+		p := pattern.Interface().(*ast.Ident)
+		v := val.Interface().(*ast.Ident)
+		return p == nil && v == nil || p != nil && v != nil && p.Name == v.Name
+	case objectPtrType, positionType:
+		// object pointers and token positions always match
+		return true
+	case callExprType:
+		// For calls, the Ellipsis fields (token.Pos) must
+		// match since that is how f(x) and f(x...) are different.
+		// Check them here but fall through for the remaining fields.
+		p := pattern.Interface().(*ast.CallExpr)
+		v := val.Interface().(*ast.CallExpr)
+		if p.Ellipsis.IsValid() != v.Ellipsis.IsValid() {
+			return false
+		}
+	}
+
+	p := reflect.Indirect(pattern)
+	v := reflect.Indirect(val)
+	if !p.IsValid() || !v.IsValid() {
+		return !p.IsValid() && !v.IsValid()
+	}
+
+	switch p.Kind() {
+	case reflect.Slice:
+		if p.Len() != v.Len() {
+			return false
+		}
+		for i := 0; i < p.Len(); i++ {
+			if !match(m, p.Index(i), v.Index(i)) {
+				return false
+			}
+		}
+		return true
+
+	case reflect.Struct:
+		for i := 0; i < p.NumField(); i++ {
+			if !match(m, p.Field(i), v.Field(i)) {
+				return false
+			}
+		}
+		return true
+
+	case reflect.Interface:
+		return match(m, p.Elem(), v.Elem())
+	}
+
+	// Handle token integers, etc.
+	return p.Interface() == v.Interface()
+}

--- a/internal/imports/gofmt_simplify.go
+++ b/internal/imports/gofmt_simplify.go
@@ -1,0 +1,169 @@
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package imports
+
+import (
+	"go/ast"
+	"go/token"
+	"reflect"
+)
+
+type simplifier struct{}
+
+func (s simplifier) Visit(node ast.Node) ast.Visitor {
+	switch n := node.(type) {
+	case *ast.CompositeLit:
+		// array, slice, and map composite literals may be simplified
+		outer := n
+		var keyType, eltType ast.Expr
+		switch typ := outer.Type.(type) {
+		case *ast.ArrayType:
+			eltType = typ.Elt
+		case *ast.MapType:
+			keyType = typ.Key
+			eltType = typ.Value
+		}
+
+		if eltType != nil {
+			var ktyp reflect.Value
+			if keyType != nil {
+				ktyp = reflect.ValueOf(keyType)
+			}
+			typ := reflect.ValueOf(eltType)
+			for i, x := range outer.Elts {
+				px := &outer.Elts[i]
+				// look at value of indexed/named elements
+				if t, ok := x.(*ast.KeyValueExpr); ok {
+					if keyType != nil {
+						s.simplifyLiteral(ktyp, keyType, t.Key, &t.Key)
+					}
+					x = t.Value
+					px = &t.Value
+				}
+				s.simplifyLiteral(typ, eltType, x, px)
+			}
+			// node was simplified - stop walk (there are no subnodes to simplify)
+			return nil
+		}
+
+	case *ast.SliceExpr:
+		// a slice expression of the form: s[a:len(s)]
+		// can be simplified to: s[a:]
+		// if s is "simple enough" (for now we only accept identifiers)
+		//
+		// Note: This may not be correct because len may have been redeclared in
+		//       the same package. However, this is extremely unlikely and so far
+		//       (April 2022, after years of supporting this rewrite feature)
+		//       has never come up, so let's keep it working as is (see also #15153).
+		//
+		// Also note that this code used to use go/ast's object tracking,
+		// which was removed in exchange for go/parser.Mode.SkipObjectResolution.
+		// False positives are extremely unlikely as described above,
+		// and go/ast's object tracking is incomplete in any case.
+		if n.Max != nil {
+			// - 3-index slices always require the 2nd and 3rd index
+			break
+		}
+		if s, _ := n.X.(*ast.Ident); s != nil {
+			// the array/slice object is a single identifier
+			if call, _ := n.High.(*ast.CallExpr); call != nil && len(call.Args) == 1 && !call.Ellipsis.IsValid() {
+				// the high expression is a function call with a single argument
+				if fun, _ := call.Fun.(*ast.Ident); fun != nil && fun.Name == "len" {
+					// the function called is "len"
+					if arg, _ := call.Args[0].(*ast.Ident); arg != nil && arg.Name == s.Name {
+						// the len argument is the array/slice object
+						n.High = nil
+					}
+				}
+			}
+		}
+		// Note: We could also simplify slice expressions of the form s[0:b] to s[:b]
+		//       but we leave them as is since sometimes we want to be very explicit
+		//       about the lower bound.
+		// An example where the 0 helps:
+		//       x, y, z := b[0:2], b[2:4], b[4:6]
+		// An example where it does not:
+		//       x, y := b[:n], b[n:]
+
+	case *ast.RangeStmt:
+		// - a range of the form: for x, _ = range v {...}
+		// can be simplified to: for x = range v {...}
+		// - a range of the form: for _ = range v {...}
+		// can be simplified to: for range v {...}
+		if isBlank(n.Value) {
+			n.Value = nil
+		}
+		if isBlank(n.Key) && n.Value == nil {
+			n.Key = nil
+		}
+	}
+
+	return s
+}
+
+func (s simplifier) simplifyLiteral(typ reflect.Value, astType, x ast.Expr, px *ast.Expr) {
+	ast.Walk(s, x) // simplify x
+
+	// if the element is a composite literal and its literal type
+	// matches the outer literal's element type exactly, the inner
+	// literal type may be omitted
+	if inner, ok := x.(*ast.CompositeLit); ok {
+		if match(nil, typ, reflect.ValueOf(inner.Type)) {
+			inner.Type = nil
+		}
+	}
+	// if the outer literal's element type is a pointer type *T
+	// and the element is & of a composite literal of type T,
+	// the inner &T may be omitted.
+	if ptr, ok := astType.(*ast.StarExpr); ok {
+		if addr, ok := x.(*ast.UnaryExpr); ok && addr.Op == token.AND {
+			if inner, ok := addr.X.(*ast.CompositeLit); ok {
+				if match(nil, reflect.ValueOf(ptr.X), reflect.ValueOf(inner.Type)) {
+					inner.Type = nil // drop T
+					*px = inner      // drop &
+				}
+			}
+		}
+	}
+}
+
+func isBlank(x ast.Expr) bool {
+	ident, ok := x.(*ast.Ident)
+	return ok && ident.Name == "_"
+}
+
+func simplify(f *ast.File) {
+	// remove empty declarations such as "const ()", etc
+	removeEmptyDeclGroups(f)
+
+	var s simplifier
+	ast.Walk(s, f)
+}
+
+func removeEmptyDeclGroups(f *ast.File) {
+	i := 0
+	for _, d := range f.Decls {
+		if g, ok := d.(*ast.GenDecl); !ok || !isEmpty(f, g) {
+			f.Decls[i] = d
+			i++
+		}
+	}
+	f.Decls = f.Decls[:i]
+}
+
+func isEmpty(f *ast.File, g *ast.GenDecl) bool {
+	if g.Doc != nil || g.Specs != nil {
+		return false
+	}
+
+	for _, c := range f.Comments {
+		// if there is a comment in the declaration, it is not considered empty
+		if g.Pos() <= c.Pos() && c.End() <= g.End() {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/imports/imports.go
+++ b/internal/imports/imports.go
@@ -34,6 +34,8 @@ type Options struct {
 	// into another group after 3rd-party packages.
 	LocalPrefix string
 
+	MergeAll bool // Merge all imports into a single group
+
 	Fragment  bool // Accept fragment of a source file (no package statement)
 	AllErrors bool // Report all errors (not just the first 10 on different lines)
 
@@ -114,7 +116,7 @@ func ApplyFixes(fixes []*ImportFix, filename string, src []byte, opt *Options, e
 // formatted file, and returns the postpocessed result.
 func formatFile(fset *token.FileSet, file *ast.File, src []byte, adjust func(orig []byte, src []byte) []byte, opt *Options) ([]byte, error) {
 	mergeImports(file)
-	sortImports(opt.LocalPrefix, fset.File(file.Pos()), file)
+	sortImports(opt.LocalPrefix, opt.MergeAll, fset.File(file.Pos()), file)
 	var spacesBefore []string // import paths we need spaces before
 	for _, impSection := range astutil.Imports(fset, file) {
 		// Within each block of contiguous imports, see if any

--- a/internal/imports/imports.go
+++ b/internal/imports/imports.go
@@ -36,6 +36,8 @@ type Options struct {
 
 	MergeAll bool // Merge all imports into a single group
 
+	Simplify bool // Simplify code like gofmt -s
+
 	Fragment  bool // Accept fragment of a source file (no package statement)
 	AllErrors bool // Report all errors (not just the first 10 on different lines)
 
@@ -133,6 +135,10 @@ func formatFile(fset *token.FileSet, file *ast.File, src []byte, adjust func(ori
 			lastGroup = groupNum
 		}
 
+	}
+
+	if opt.Simplify {
+		simplify(file)
 	}
 
 	printerMode := printer.UseSpaces

--- a/internal/imports/sortimports.go
+++ b/internal/imports/sortimports.go
@@ -19,7 +19,7 @@ import (
 // It also removes duplicate imports when it is possible to do so without data loss.
 //
 // It may mutate the token.File and the ast.File.
-func sortImports(localPrefix string, tokFile *token.File, f *ast.File) {
+func sortImports(localPrefix string, mergeAll bool, tokFile *token.File, f *ast.File) {
 	for i, d := range f.Decls {
 		d, ok := d.(*ast.GenDecl)
 		if !ok || d.Tok != token.IMPORT {
@@ -38,18 +38,24 @@ func sortImports(localPrefix string, tokFile *token.File, f *ast.File) {
 			continue
 		}
 
-		// Identify and sort runs of specs on successive lines.
-		i := 0
-		specs := d.Specs[:0]
-		for j, s := range d.Specs {
-			if j > i && tokFile.Line(s.Pos()) > 1+tokFile.Line(d.Specs[j-1].End()) {
-				// j begins a new run.  End this one.
-				specs = append(specs, sortSpecs(localPrefix, tokFile, f, d.Specs[i:j])...)
-				i = j
+		// Identify and sort runs of specs.
+		// When mergeAll is true, treat all specs as a single run.
+		if mergeAll {
+			d.Specs = sortSpecs(localPrefix, tokFile, f, d.Specs)
+		} else {
+			// Identify and sort runs of specs on successive lines.
+			i := 0
+			specs := d.Specs[:0]
+			for j, s := range d.Specs {
+				if j > i && tokFile.Line(s.Pos()) > 1+tokFile.Line(d.Specs[j-1].End()) {
+					// j begins a new run.  End this one.
+					specs = append(specs, sortSpecs(localPrefix, tokFile, f, d.Specs[i:j])...)
+					i = j
+				}
 			}
+			specs = append(specs, sortSpecs(localPrefix, tokFile, f, d.Specs[i:])...)
+			d.Specs = specs
 		}
-		specs = append(specs, sortSpecs(localPrefix, tokFile, f, d.Specs[i:])...)
-		d.Specs = specs
 
 		// Deduping can leave a blank line before the rparen; clean that up.
 		// Ignore line directives.


### PR DESCRIPTION
* `-merge-all` to merge all import blocks into one before sorting
* `-s` to match `gofmt -s`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onboard-inc/golang-tools/1)
<!-- Reviewable:end -->
